### PR TITLE
升级cookie mock源为server源

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,31 @@ json路径/mock/data/query/table.json
 
 template路径/mock/data/query/table.template
 
+4. mockserver
+
+mockserver是通过配置mock服务地址以及mock服务需要的额外请求参数来获得mock服务器提供的响应结果
+
+配置文件如下:
+
+```
+    "mockserver": {
+        "host": "http://localhost:8080/",
+        "mockserverParams": {
+
+        },
+        "rejectUnauthorized": false,
+        "secureProtocol": "SSLv3_method",
+        "proxy": ""
+    }
+```
+
+- host：mock域名
+- secureProtocol：SSL协议，根据安装的OpenSSL设置。比如SSLv3_method，即设置为SSL第三版。具体可参考[SSL_METHODS](https://www.openssl.org/docs/manmaster/ssl/ssl.html#DEALING_WITH_PROTOCOL_METHODS "SSL_METHODS")
+- proxy:代理
+- mockserverParams： mock服务器可能需要的额外参数，拼接于请求url后
+
+为了使mockserver在没有相应响应时不影响继续使用其他mock源，特约定，在响应状态码为200时才使用mockserver的响应数据，不然使用其他mock源
+
 ### 如何自定义mock数据源
 
 mock数据源实现getData方法
@@ -198,3 +223,7 @@ mock数据源实现getData方法
 - 初始化时，当未设置config文件路径时，优先使用/mock/config/mockConfig.json, 同时如果新的不存在则兼容老的路径，并给出dperaciate提示。建议升级后进行迁移，简化工程目录
 - 新增配置项的热更新，避免切换数据源时需要重新启动应用
 - 代码格式化
+
+### 0.1.1
+- 增加新的mock源：mockserver
+- 更改package.json的test脚本，使windows环境也能启动

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ biz-mock支持通过json静态数据，随机模板数据，cookie原酸数据�
 ## 功能
 
 - 拦截ajax请求
-- 三种mock数据源，json，模板和cookie
+- 四种mock数据源，json，模板和cookie以及mockserver
 - 支持自定义拦截器
 
 ## 安装
@@ -90,7 +90,7 @@ mock静态文件目录：
 ### mockConfig.json:
 
 	{
-    "dataSource": ["cookie", "template", "json"],
+    "dataSource": ["cookie", "mockserver", "template", "json"],
     "json": {
         "path": "/mock/data/",
         "wrap": false
@@ -103,14 +103,22 @@ mock静态文件目录：
     },
     "template": {
         "path": "/mock/template/"
+    },
+    "mockserver": {
+        "host": "http://localhost:8080/",
+        "mockserverParams": {
+        },
+        "rejectUnauthorized": false,
+        "secureProtocol": "SSLv3_method",
+        "proxy": ""
     }
 }
 
 ### mock数据源
 
-`dataSource`是mock数据源的集合，目前有原生提供三种数据源cookie，template和json
+`dataSource`是mock数据源的集合，目前有原生提供四种数据源cookie，template和json以及mockserver
 
-数据源在集合中的排序规定了数据源的优先级，索引越小，优先级越高。如上面例子中，会首先查找cookie数据源，如果cookie数据源没有数据，那么会查找template数据源，仍然没有，继续查找json数据源。三种数据源都没有的话，会返回404
+数据源在集合中的排序规定了数据源的优先级，索引越小，优先级越高。如上面例子中，会首先查找cookie数据源，如果cookie数据源没有数据，接着是mockserver数据源，如果还没有，那么会查找template数据源，仍然没有，继续查找json数据源。四种数据源都没有的话，会返回404
 
 1.json
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ biz-mock支持通过json静态数据，随机模板数据，cookie原酸数据�
 ## 功能
 
 - 拦截ajax请求
-- 四种mock数据源，json，模板和cookie以及mockserver
+- 三种mock数据源，json，模板和server
 - 支持自定义拦截器
 
 ## 安装
@@ -90,29 +90,27 @@ mock静态文件目录：
 ### mockConfig.json:
 
 	{
-    "dataSource": ["cookie", "mockserver", "template", "json"],
+    "dataSource": ["server", "json", "template"],
     "json": {
         "path": "/mock/data/",
         "wrap": false
     },
-    "cookie": {
-        "host": "http://zhitou.xuri.p4p.sogou.com/",
+    "server": {
+        "host": "http://localhost:8080/",
+        "serverParams": {
+            "index": 1
+        },
+        "statusCode": [200],
         "rejectUnauthorized": false,
         "secureProtocol": "SSLv3_method",
-        "cookie": ""
+        "cookie": "",
+        "proxy": ""
     },
     "template": {
         "path": "/mock/template/"
-    },
-    "mockserver": {
-        "host": "http://localhost:8080/",
-        "mockserverParams": {
-        },
-        "rejectUnauthorized": false,
-        "secureProtocol": "SSLv3_method",
-        "proxy": ""
     }
 }
+
 
 ### mock数据源
 
@@ -146,20 +144,27 @@ template是通过数据模板生成模拟数据
 
 生成器选用[http://mockjs.com/](http://mockjs.com/ "Mock.js")
 
-3.cookie
+3.server
 
-cookie是通过在配置文件中拷贝cookie，实现免登陆直接请求数据
+server是通过在配置文件中配置host，cookie，额外参数serverParams等，实现从其他服务中获取请求数据的功能
 
 配置文件如下：
 
-    "cookie": {
-	    "host": ,
-	    "secureProtocol": ,
-	    "cookie": ,
-		"proxy":
+    "server": {
+        "host": "http://localhost:8080/",
+        "serverParams": {
+            "index": 1
+        },
+        "statusCode": [200],
+        "rejectUnauthorized": false,
+        "secureProtocol": "SSLv3_method",
+        "cookie": "",
+        "proxy": ""
     }
 
 - host：访问域名，支持http和https
+- serverParams： 可能额外需要的参数
+- statusCode: 配置需要返回结果的响应码，默认是200，如果服务的响应码不在此列表中，则从其他mock源获取数据
 - secureProtocol：SSL协议，根据安装的OpenSSL设置。比如SSLv3_method，即设置为SSL第三版。具体可参考[SSL_METHODS](https://www.openssl.org/docs/manmaster/ssl/ssl.html#DEALING_WITH_PROTOCOL_METHODS "SSL_METHODS")
 - cookie: cookie
 - proxy:代理
@@ -174,30 +179,6 @@ json路径/mock/data/query/table.json
 
 template路径/mock/data/query/table.template
 
-4. mockserver
-
-mockserver是通过配置mock服务地址以及mock服务需要的额外请求参数来获得mock服务器提供的响应结果
-
-配置文件如下:
-
-```
-    "mockserver": {
-        "host": "http://localhost:8080/",
-        "mockserverParams": {
-
-        },
-        "rejectUnauthorized": false,
-        "secureProtocol": "SSLv3_method",
-        "proxy": ""
-    }
-```
-
-- host：mock域名
-- secureProtocol：SSL协议，根据安装的OpenSSL设置。比如SSLv3_method，即设置为SSL第三版。具体可参考[SSL_METHODS](https://www.openssl.org/docs/manmaster/ssl/ssl.html#DEALING_WITH_PROTOCOL_METHODS "SSL_METHODS")
-- proxy:代理
-- mockserverParams： mock服务器可能需要的额外参数，拼接于请求url后
-
-为了使mockserver在没有相应响应时不影响继续使用其他mock源，特约定，在响应状态码为200时才使用mockserver的响应数据，不然使用其他mock源
 
 ### 如何自定义mock数据源
 
@@ -233,5 +214,6 @@ mock数据源实现getData方法
 - 代码格式化
 
 ### 0.1.1
-- 增加新的mock源：mockserver
+- 把cookie mock源升级为server源，通过在配置文件中配置host，cookie，额外参数serverParams等，实现从其他服务中获取请求数据的功能
+- server源可以用列表方式配置多种配置，会依次尝试直至获取结果
 - 更改package.json的test脚本，使windows环境也能启动

--- a/mock/config/mockConfig.json
+++ b/mock/config/mockConfig.json
@@ -1,26 +1,32 @@
 {
-    "dataSource": ["mockserver", "json", "template", "cookie"],
+    "dataSource": ["server", "json", "template"],
     "json": {
         "path": "/mock/data/",
         "wrap": false
     },
-    "cookie": {
-        "host": "",
+    "server": [{
+        "host": "http://localhost:8080/",
+        "serverParams": {
+            "index": 1
+        },
+        "statusCode": [200],
         "rejectUnauthorized": false,
         "secureProtocol": "SSLv3_method",
         "cookie": "",
         "proxy": ""
-    },
-    "template": {
-        "path": "/mock/template/"
-    },
-    "mockserver": {
-        "host": "http://localhost:8080/",
-        "mockserverParams": {
-
+    }, {
+        "host": "http://localhost:8081/",
+        "serverParams": {
+            "index": 2
         },
+        "statusCode": [200],
         "rejectUnauthorized": false,
         "secureProtocol": "SSLv3_method",
+        "cookie": "",
         "proxy": ""
+    }],
+    "template": {
+        "path": "/mock/template/"
     }
+
 }

--- a/mock/config/mockConfig.json
+++ b/mock/config/mockConfig.json
@@ -1,5 +1,5 @@
 {
-    "dataSource": ["json", "template", "cookie"],
+    "dataSource": ["mockserver", "json", "template", "cookie"],
     "json": {
         "path": "/mock/data/",
         "wrap": false
@@ -13,5 +13,14 @@
     },
     "template": {
         "path": "/mock/template/"
+    },
+    "mockserver": {
+        "host": "http://localhost:8080/",
+        "mockserverParams": {
+
+        },
+        "rejectUnauthorized": false,
+        "secureProtocol": "SSLv3_method",
+        "proxy": ""
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "biz-mock",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "mock center",
   "main": "src/biz-mock.js",
   "scripts": {
-    "test": "istanbul cover -v --print both -- vows --spec test/biz-mock-test.js"
+    "test": "istanbul cover -v --print both -- ./node_modules/vows/bin/vows --spec test/biz-mock-test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biz-mock",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "mock center",
   "main": "src/biz-mock.js",
   "scripts": {

--- a/test/biz-mock-test.js
+++ b/test/biz-mock-test.js
@@ -30,7 +30,7 @@ function start(config, serverPort){
     //起一个假的mock服务器
     mockserver = http.createServer(function(req, res) {
         //用于测试mockServer的接口名
-        if (req.url === '/query/mockserver.action') {
+        if (req.url.indexOf('/query/mockserver.action') > -1) {
             res.writeHead(200, {'Content-Type': 'application/json'});  
             var data = {  
                 "name":"nodejs",  

--- a/test/biz-mock-test.js
+++ b/test/biz-mock-test.js
@@ -13,7 +13,7 @@ var path = require('path'),
 
 var root = path.join(__dirname),
     mockPath = path.join(__dirname, 'mock'),
-    server, mockserver;
+    server, mockserver, mockserverTwo;
 function start(config, serverPort){
     mock.start(config);
 
@@ -30,11 +30,12 @@ function start(config, serverPort){
     //起一个假的mock服务器
     mockserver = http.createServer(function(req, res) {
         //用于测试mockServer的接口名
-        if (req.url.indexOf('/query/mockserver.action') > -1) {
+        if (req.url.indexOf('/query/server.action') > -1) {
             res.writeHead(200, {'Content-Type': 'application/json'});  
             var data = {  
                 "name":"nodejs",  
-                "value":"mockserver"  
+                "value":"server",
+                "from": "server1"  
             };  
             res.end(JSON.stringify(data));
         } else {
@@ -42,6 +43,22 @@ function start(config, serverPort){
             res.end();
         } 
     }).listen(8080);
+
+    mockserverTwo = http.createServer(function(req, res) {
+        //用于测试mockServer的接口名
+        if (req.url.indexOf('/query/server.action') > -1) {
+            res.writeHead(200, {'Content-Type': 'application/json'});  
+            var data = {  
+                "name":"nodejs",  
+                "value":"server",
+                "from": "server2"  
+            };  
+            res.end(JSON.stringify(data));
+        } else {
+            res.writeHead(404);
+            res.end();
+        } 
+    }).listen(8081);
 
 }
 
@@ -91,24 +108,29 @@ var a = vows.describe('biz-mock').addBatch({
             var body = JSON.parse(res.body);
         }
     },
-    'Get mock data from mockserver': {
+    'Get mock data from server': {
         topic: function() {
-            request('http://127.0.0.1:8090/query/mockserver.action', this.callback);
+            request('http://127.0.0.1:8090/query/server.action', this.callback);
         },
-        'query http://127.0.0.1:8090/query/mockserver.action, status code should be 200': function(err, res, body) {
+        'query http://127.0.0.1:8090/query/server.action, status code should be 200': function(err, res, body) {
             assert.equal(res.statusCode, 200);
         },
-        'query http://127.0.0.1:8090/query/mockserver.action, data should have a property name equal value': function(err, res, body) {
+        'query http://127.0.0.1:8090/query/server.action, data should have a property name equal value': function(err, res, body) {
             assert.isTrue(JSON.parse(res.body).hasOwnProperty('value'));
         },
-        'query http://127.0.0.1:8090/query/mockserver.action, the property of name should be "nodejs"': function(err, res, body) {
+        'query http://127.0.0.1:8090/query/server.action, the property of name should be "nodejs"': function(err, res, body) {
             var body = JSON.parse(res.body);
             assert.equal(body.name, 'nodejs');
-        }
+        },
+        'query http://127.0.0.1:8090/query/server.action, the data should from server1': function(err, res, body) {
+            var body = JSON.parse(res.body);
+            assert.equal(body.from, 'server1');
+        },
     },
     teardown: function(topic) {
         console.log('server close')
         server.close();
         mockserver.close();
+        mockserverTwo.close();
     }
 }).export(module)


### PR DESCRIPTION
把cookie mock源升级为server源，通过在配置文件中配置host，cookie，额外参数serverParams等，实现从其他服务中获取请求数据的功能