### PR TITLE
url拼接问题

### DIFF
--- a/mock/config/mockConfig.json
+++ b/mock/config/mockConfig.json
@@ -5,7 +5,7 @@
         "wrap": false
     },
     "server": [{
-        "host": "http://localhost:8080/",
+        "host": "http://localhost:8080/mock",
         "serverParams": {
             "index": 1
         },

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,0 +1,31 @@
+/*
+ * @Author: xiongsheng
+ * @Date:   2017-09-29 16:37:48
+ * @Last Modified by:   xiongsheng
+ * @Last Modified time: 2017-09-29 16:43:51
+ */
+var Utils = {
+    //将参数对象转为字符串
+    serialize: function(obj) {
+        if (typeof obj === 'string') {
+            return obj;
+        }
+        return Object.keys(obj).map(function(key) {
+            return [encodeURIComponent(key), encodeURIComponent(obj[key])].join('=')
+        }).join('&');
+    },
+    //拼接url
+    concatUrl: function(urlA, urlB) {
+        var endAFlag = urlA[urlA.length - 1] === '/',
+            firstBFlag = urlB[0] === '/';
+        if (endAFlag && firstBFlag) {
+            return urlA + urlB.slice(1);
+        } else if (!endAFlag && !firstBFlag) {
+            return urlA + '/' + urlB;
+        } else {
+            return urlA + urlB;
+        }
+    }
+}
+
+module.exports = Utils;

--- a/src/biz-mock.js
+++ b/src/biz-mock.js
@@ -13,6 +13,7 @@ var MockJs = require('mockjs'),
     thunkify = require('thunkify'),
     Url = require('url'),
     watch = require('watch'),
+    Utils = require('./Utils'),
     router = new director.http.Router();
 
 var CONFIG_FILE_NAME = 'mockConfig.json';
@@ -46,15 +47,8 @@ var logger = {
     }
 };
 
-//将参数对象转为字符串
-function serialize(obj) {
-    if (typeof obj === 'string') {
-        return obj;
-    }
-    return Object.keys(obj).map(function(key) {
-        return [encodeURIComponent(key), encodeURIComponent(obj[key])].join('=')
-    }).join('&');
-}
+var serialize = Utils.serialize;
+var concatUrl = Utils.concatUrl;
 
 function Mock() {
     this.thunkGetJsonData = thunkify(this._getJsonData);
@@ -293,7 +287,8 @@ Mock.prototype._getServerData = function(configs, url, req, res, cb) {
         paramsString = serialize(serverParams),
         //判断连接符是&还是?
         connector = req.url.indexOf('?') > '-1' ? '&' : '?',
-        url = Url.resolve(configs.host, req.url);
+        //server的host可能域名+router，使用Url.resolve会丢失router，所以改为拼接
+        url = concatUrl(configs.host, req.url);
     //mockserver拼接url后的参数
     if (paramsString) {
         url += connector + paramsString;

--- a/test/biz-mock-test.js
+++ b/test/biz-mock-test.js
@@ -9,11 +9,14 @@ var path = require('path'),
     request = require('request'),
     _ = require('underscore'),
     http = require('http'),
+    concatUrl = require('../src/Utils').concatUrl,
     httpServer = require('http-server');
 
 var root = path.join(__dirname),
     mockPath = path.join(__dirname, 'mock'),
     server, mockserver, mockserverTwo;
+
+
 function start(config, serverPort){
     mock.start(config);
 
@@ -126,6 +129,23 @@ var a = vows.describe('biz-mock').addBatch({
             var body = JSON.parse(res.body);
             assert.equal(body.from, 'server1');
         },
+    },
+    'Test url concat': {
+        'both has /': function() {
+            var a = 'http://localhost/mock/';
+            var b = '/test.action';
+            assert.equal(concatUrl(a, b), 'http://localhost/mock/test.action');
+        },
+        'neither has /': function () {
+            var a = 'http://localhost/mock';
+            var b = 'test.action';
+            assert.equal(concatUrl(a, b), 'http://localhost/mock/test.action');
+        },
+        'has one /': function () {
+            var a = 'http://localhost/mock';
+            var b = '/test.action';
+            assert.equal(concatUrl(a, b), 'http://localhost/mock/test.action');
+        }
     },
     teardown: function(topic) {
         console.log('server close')


### PR DESCRIPTION
之前的url拼接使用的是Url.resolve方法，会导致丢失配置的host中域名后面的路由，但是在server服务中，配置的服务路径可能是需要这部分路由来匹配mock服务的action的，所以应该使用拼接